### PR TITLE
Add podspec to repository

### DIFF
--- a/JSBadgeView.podspec
+++ b/JSBadgeView.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name     = 'JSBadgeView'
+  s.version  = '1.3.2'
+  s.platform = :ios
+  s.license  = 'MIT'
+  s.summary  = 'Customizable UIKit badge view like the one on applications in the iOS springboard.'
+  s.homepage = 'https://github.com/JaviSoto/JSBadgeView'
+  s.author   = { 'Javier Soto' => 'ios@javisoto.es' }
+  s.source   = { :git => 'https://github.com/JaviSoto/JSBadgeView.git', :tag => s.version.to_s }
+
+  s.description = 'Customizable UIKit badge view like the one on applications in the iOS springboard. Very optimized for performance: drawn entirely using CoreGraphics.'
+
+  s.source_files = 'JSBadgeView/*.{h,m}'
+  s.preserve_paths  = 'JSBadgeView_SampleProject'
+  s.framework    = 'QuartzCore'
+  s.requires_arc = true
+end


### PR DESCRIPTION
Besides making sense to have the podspec directly in the repository, it also allows advanced [CocoaPods](http://cocoapods.org) [usages](http://guides.cocoapods.org/using/the-podfile.html) like using the `:head`, `:path` or `:git`/`:commit` options.

I don't know when it got deleted after #3.
