### PR TITLE
Make sure badge is always round

### DIFF
--- a/JSBadgeView/JSBadgeView.m
+++ b/JSBadgeView/JSBadgeView.m
@@ -155,7 +155,7 @@ static BOOL JSBadgeViewIsUIKitFlatMode(void)
     const CGFloat superviewHeight = superviewBounds.size.height;
     
     newFrame.size.width = MAX(viewWidth, viewHeight);
-    newFrame.size.height = MAX(viewHeight, viewWidth);
+    newFrame.size.height = viewHeight;
     
     switch (self.badgeAlignment) {
         case JSBadgeViewAlignmentTopLeft:

--- a/JSBadgeView/JSBadgeView.m
+++ b/JSBadgeView/JSBadgeView.m
@@ -154,8 +154,8 @@ static BOOL JSBadgeViewIsUIKitFlatMode(void)
     const CGFloat superviewWidth = superviewBounds.size.width;
     const CGFloat superviewHeight = superviewBounds.size.height;
     
-    newFrame.size.width = viewWidth;
-    newFrame.size.height = viewHeight;
+    newFrame.size.width = MAX(viewWidth, viewHeight);
+    newFrame.size.height = MAX(viewHeight, viewWidth);
     
     switch (self.badgeAlignment) {
         case JSBadgeViewAlignmentTopLeft:


### PR DESCRIPTION
Sometimes when the text is too small, the badge is oval instead of round. This fix makes sure the badge is always large enough to fit the text, yet round at the same time. See also #33 