### PR TITLE
set badge text with NSUInteger number. Hide if number is 0

### DIFF
--- a/JSBadgeView/JSBadgeView.h
+++ b/JSBadgeView/JSBadgeView.h
@@ -39,6 +39,13 @@ typedef NS_ENUM(NSUInteger, JSBadgeViewAlignment)
 
 @property (nonatomic, copy) NSString *badgeText;
 
+@property (nonatomic, assign) NSUInteger badgeNumber;
+
+/**
+ *  Hides badge view if badgeNumber is 0. Default is NO.
+ */
+@property (nonatomic, assign) BOOL hidesIfZero;
+
 #pragma mark - Customization
 
 @property (nonatomic, assign) JSBadgeViewAlignment badgeAlignment UI_APPEARANCE_SELECTOR;

--- a/JSBadgeView_SampleProject.xcodeproj/project.pbxproj
+++ b/JSBadgeView_SampleProject.xcodeproj/project.pbxproj
@@ -142,7 +142,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = JS;
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0620;
 				ORGANIZATIONNAME = "Javier Soto";
 			};
 			buildConfigurationList = 1D4B46C715BFA20D00143C2C /* Build configuration list for PBXProject "JSBadgeView_SampleProject" */;
@@ -211,9 +211,11 @@
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -246,9 +248,11 @@
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;


### PR DESCRIPTION
Usually we just set the badge text with a number string and we want to hide badge if the number is 0, so I add this little feature. 